### PR TITLE
iOS: Add UICollectionView example

### DIFF
--- a/app/controllers/ios/collectionview.js
+++ b/app/controllers/ios/collectionview.js
@@ -1,0 +1,68 @@
+(function (container) {
+
+	var UIScreen = require('UIKit/UIScreen'),
+	    UICollectionViewFlowLayout = require('UIKit/UICollectionViewFlowLayout'),
+	    UIView = require('UIKit/UIView'),
+	    UIColor = require('UIKit/UIColor'),
+	    UICollectionView = require('UIKit/UICollectionView'),
+	    UICollectionViewCell = require('UIKit/UICollectionViewCell'),
+	    UIEdgeInsetsMake = require('UIKit').UIEdgeInsetsMake,
+	    CGSizeMake = require('CoreGraphics').CGSizeMake,
+	    CGRectMake = require('CoreGraphics').CGRectMake,
+		colors = [],
+		numberOfColors = 50;
+
+	// Subclass delegate + data source
+	var CollectionViewDataSourceAndDelegate = require('subclasses/collectionviewdatasourcedelegate')
+	var dataSourceDelegate = new CollectionViewDataSourceAndDelegate();
+    
+	// Return the number of collection view cells
+    dataSourceDelegate.numberOfCells = function(collectionView, indexPath) {
+        return colors.length;
+    };
+    
+	// Return the configured UICollectionViewCell
+    dataSourceDelegate.cellForItem = function(collectionView, indexPath) {
+        var cell = collectionView.dequeueReusableCellWithReuseIdentifierForIndexPath("Cell", indexPath);
+        cell.backgroundColor = colors[indexPath.row];
+        
+        return cell;
+    };
+    
+	// Triggered when we click on a certain cell
+    dataSourceDelegate.didSelectItem = function(collectionView, indexPath) {
+        var cell = collectionView.cellForItemAtIndexPath(indexPath);
+        Ti.API.warn("Cell selected at Index = " + indexPath.row);
+    };
+    
+	// Generate 500 colors
+    for (var i = 0; i < 500; i++) {
+        var hue = ((Math.random() * 4294967296) % 256 / 256.0);
+        var saturation = ((Math.random() * 4294967296) % 128 / 256.0) + 0.5;
+        var brightness = ((Math.random() * 4294967296) % 128 / 256.0) + 0.5;
+        colors.push(UIColor.colorWithHueSaturationBrightnessAlpha(hue, saturation, brightness, 1));
+    }
+    
+	// Calculate the cell specs 
+    var screenRect = UIScreen.mainScreen().bounds;
+    screenRect = CGRectMake(0 , 0, UIScreen.mainScreen().bounds.size.width, UIScreen.mainScreen().bounds.size.height - 64);
+    var cellWidth = screenRect.size.width / 3.0;
+    
+	// Create the cell layout and assign the size 
+    var layout = new UICollectionViewFlowLayout()
+    layout.sectionInset = UIEdgeInsetsMake(0, 0, 0, 0);
+    layout.itemSize = CGSizeMake(cellWidth, cellWidth);
+    layout.minimumLineSpacing = 0;
+    layout.minimumInteritemSpacing = 0;
+         
+	// Create the UICollectionView, set the delegate, datasource and layout
+    collectionView = UICollectionView.alloc().initWithFrameCollectionViewLayout(screenRect, layout);
+    collectionView.registerClassForCellWithReuseIdentifier(UICollectionViewCell.class(), "Cell");
+    collectionView.backgroundColor = UIColor.clearColor();
+    collectionView.setDataSource(dataSourceDelegate);
+    collectionView.setDelegate(dataSourceDelegate);
+    
+	// Add the view to our Titanium Mobile view
+	container.add(collectionView);
+
+})($.container);

--- a/app/lib/ios/subclasses/collectionviewdatasourcedelegate.js
+++ b/app/lib/ios/subclasses/collectionviewdatasourcedelegate.js
@@ -1,0 +1,40 @@
+var CollectionViewDataSourceAndDelegate = Hyperloop.defineClass('CollectionViewDataSourceAndDelegate', 'NSObject', ['UICollectionViewDataSource', 'UICollectionViewDelegate', 'UICollectionViewDelegateFlowLayout']);
+
+CollectionViewDataSourceAndDelegate.addMethod({
+	selector: 'collectionView:numberOfItemsInSection:',
+	instance: true,
+	arguments: ['UICollectionView', 'long'],
+	returnType: 'long',
+	callback: function (collectionView, indexPath) {
+		if (this.numberOfCells) {
+			return this.numberOfCells(collectionView, indexPath);
+		}
+		return null;
+	}
+});
+    
+CollectionViewDataSourceAndDelegate.addMethod({
+	selector: 'collectionView:cellForItemAtIndexPath:',
+	instance: true,
+	arguments: ['UICollectionView', 'NSIndexPath'],
+	returnType: 'UICollectionViewCell',
+	callback: function (collectionView, indexPath) {
+		if (this.cellForItem) {
+			return this.cellForItem(collectionView, indexPath);
+		}
+		return null;
+	}
+});
+    
+CollectionViewDataSourceAndDelegate.addMethod({
+    selector: 'collectionView:didSelectItemAtIndexPath:',
+    instance: true,
+    arguments: ['UICollectionView', 'NSIndexPath'],
+    callback: function (collectionView, indexPath) {
+        if (this.didSelectItem) {
+            this.didSelectItem(collectionView, indexPath);
+        }
+    }
+});
+
+module.exports = CollectionViewDataSourceAndDelegate;

--- a/app/views/index.xml
+++ b/app/views/index.xml
@@ -14,6 +14,8 @@
 					<ListItem itemId="label" title="Styled Labels"/>
 					<ListItem itemId="drawrect" title="Custom Drawing"/>
 					<ListItem itemId="touches" title="Touches"/>
+					<ListItem itemId="tableview" platform="ios" title="Table View"/>
+					<ListItem itemId="collectionview" platform="ios" title="Collection View"/>
 					<ListItem itemId="calendar" platform="ios" title="Calendar (3rd Party Integration)"/>
 					<ListItem itemId="charting" platform="ios" title="Charting (3rd party integration)"/>
 					<ListItem itemId="alert" title="Alert"/>
@@ -23,7 +25,6 @@
 					<ListItem itemId="custom" platform="ios" title="Custom Class"/>
 					<ListItem itemId="tinder" platform="ios" title="Tinder UI"/>
 					<ListItem itemId="gravity" platform="ios" title="Gravity"/>
-					<ListItem itemId="tableview" platform="ios" title="Table View"/>
 					<ListItem itemId="snackbar" platform="android" title="Snackbar"/>
 					<ListItem itemId="blur" title="Blur"/>
 					<ListItem itemId="sizefill" title="FILL vs SIZE"/>

--- a/app/views/ios/collectionview.xml
+++ b/app/views/ios/collectionview.xml
@@ -1,0 +1,5 @@
+<Alloy>
+	<Window id="win" title="Collection View">
+		<View id="container" />
+	</Window>
+</Alloy>


### PR DESCRIPTION
Support for a the `UICollectionView` in iOS which is currently not exposed in Titanium Mobile. This example features a full-customized collection view with 3 columns per line and 500 cells with randomly-generated `UIColor` backgrounds.