### PR TITLE
Add Swift 4 image-picker example

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -1,10 +1,13 @@
 install! 'cocoapods',
          :integrate_targets => false
 
-platform :ios, '8.0'
+use_frameworks!
+platform :ios, '9.0'
+
 target 'Hyperloop_Sample' do
 	pod 'JBChartView'
 	pod 'GLCalendarView', '~> 1.2'
 	pod 'Shimmer'
 	pod 'Localytics', '~> 4.4.1'
+	pod 'ImagePicker', '~> 3.0.0'
 end

--- a/app/controllers/ios/libraries/imagePicker.js
+++ b/app/controllers/ios/libraries/imagePicker.js
@@ -1,0 +1,31 @@
+var ImagePickerController = require('ImagePicker/ImagePickerController');
+var ImagePickerDelegate = require('/subclasses/ImagePickerDelegate');
+var imagePicker;
+
+(function (container) {
+	// Prepare delegates
+	var imagePickerDelegate = new ImagePickerDelegate();
+
+	imagePickerDelegate.wrapperDidPress = function(imagePicker, images) {
+		Ti.API.info('wrapperDidPress');
+		Ti.API.info(images);
+	};
+	
+	imagePickerDelegate.doneButtonDidPress = function(imagePicker, images) {
+		Ti.API.info('doneButtonDidPress');
+		Ti.API.info(images);
+	};
+	
+	imagePickerDelegate.cancelButtonDidPressImagePicker = function(imagePicker) {
+		Ti.API.info('cancelButtonDidPress');
+	};
+
+	// Initialize image picker
+	imagePicker = new ImagePickerController();
+	imagePicker.delegate = imagePickerDelegate;
+	imagePicker.imageLimit = 5;	
+})($.container);
+
+function selectImage() {
+	TiApp.app().showModalController(imagePicker, true);
+}

--- a/app/controllers/ios/libraries/imagePicker.js
+++ b/app/controllers/ios/libraries/imagePicker.js
@@ -26,6 +26,6 @@ var imagePicker;
 	imagePicker.imageLimit = 5;	
 })($.container);
 
-function selectImage() {
+function selectPhoto() {
 	TiApp.app().showModalController(imagePicker, true);
 }

--- a/app/lib/ios/subclasses/imagePickerDelegate.js
+++ b/app/lib/ios/subclasses/imagePickerDelegate.js
@@ -1,0 +1,44 @@
+var ImagePickerDelegate = Hyperloop.defineClass('ImagePickerDelegate', 'NSObject');
+
+ImagePickerDelegate.addMethod({
+	selector: 'wrapperDidPress:images:',
+	instance: true,
+	arguments: [
+		'ImagePickerController',
+		'NSArray'
+	],
+	callback: function (imagePicker, images) {
+		if (this.wrapperDidPress) {
+			this.wrapperDidPress(imagePicker, images);
+		}
+	}
+});
+
+ImagePickerDelegate.addMethod({
+	selector: 'doneButtonDidPress:images:',
+	instance: true,
+	arguments: [
+		'ImagePickerController',
+		'NSArray'
+	],
+	callback: function (imagePicker, images) {
+		if (this.doneButtonDid) {
+			this.doneButtonDidPress(imagePicker, images);
+		}
+	}
+});
+
+ImagePickerDelegate.addMethod({
+	selector: 'cancelButtonDidPress:',
+	instance: true,
+	arguments: [
+		'ImagePickerController'
+	],
+	callback: function (imagePicker) {
+		if (this.cancelButtonDidPress) {
+			this.cancelButtonDidPress(imagePicker);
+		}
+	}
+});
+
+module.exports = ImagePickerDelegate;

--- a/app/views/libraries/imagePicker.xml
+++ b/app/views/libraries/imagePicker.xml
@@ -1,0 +1,9 @@
+<Alloy>
+	<Window id="win" title="Image Picker">
+		<View>
+			<View id="container">
+				<Button class="button" onClick="selectPhoto">Select Photo</Button>
+			</View>
+		</View>
+	</Window>
+</Alloy>

--- a/app/views/libraries/index.xml
+++ b/app/views/libraries/index.xml
@@ -5,7 +5,8 @@
                 <ListItem itemId="calendar" platform="ios" title="Calendar (GLCalendarView)"/>
                 <ListItem itemId="charting" platform="ios" title="Charting (JBChartView)"/>
                 <ListItem itemId="localytics" platform="ios" title="Localytics"/>
-                <ListItem itemId="shimmer" title="Shimmer (Shimmer)"/>    
+                <ListItem itemId="imagePicker" platform="ios" title="Image Picker (ImagePicker)"/>
+                <ListItem itemId="shimmer" title="Shimmer"/>    
             </ListSection>
         </ListView>
     </Window>

--- a/tiapp.xml
+++ b/tiapp.xml
@@ -21,6 +21,7 @@
 	<property name="run-on-main-thread" type="bool">true</property>
 	<ios>
 		<use-jscore-framework>true</use-jscore-framework>
+		<min-ios-ver>9.0</min-ios-ver>
 		<plist>
 			<dict>
 				<key>UISupportedInterfaceOrientations~iphone</key>
@@ -69,7 +70,7 @@
 		<target device="mobileweb">false</target>
 		<target device="windows">false</target>
 	</deployment-targets>
-	<sdk-version>6.2.3.GA</sdk-version>
+	<sdk-version>6.3.0.GA</sdk-version>
 	<plugins>
 		<plugin version="1.0">ti.alloy</plugin>
 		<plugin version="2.2.3">hyperloop</plugin>


### PR DESCRIPTION
This PR demonstrates the usage of a Swift 4 based CocoaPods dependency, in this case [`hyperoslo/ImagePicker`](https://github.com/hyperoslo/ImagePicker). It uses a delegate-based system and requires iOS 9+. 