### PR TITLE
Add SSDP service example

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -10,4 +10,5 @@ target 'Hyperloop_Sample' do
 	pod 'Shimmer'
 	pod 'Localytics', '~> 4.4.1'
 	pod 'MMMarkdown'
+	pod 'CocoaSSDP'
 end

--- a/app/controllers/ios/libraries/ssdp.js
+++ b/app/controllers/ios/libraries/ssdp.js
@@ -1,0 +1,70 @@
+var SSDPService = require('CocoaSSDP/SSDPService');
+var SSDPServiceBrowser = require('CocoaSSDP/SSDPServiceBrowser');
+var browser;
+
+(function(container) {
+  
+  var BrowserDelegate = Hyperloop.defineClass('BrowserDelegate', 'NSObject', 'SSDPServiceBrowserDelegate');
+
+  BrowserDelegate.addMethod({
+  	selector: 'ssdpBrowser:didNotStartBrowsingForServices:',
+  	instance: true,
+  	arguments: ['SSDPServiceBrowser', 'NSError'],
+  	callback: function (browser, error) {
+  			if (this.didNotStartBrowsingForServices) {
+  					this.didNotStartBrowsingForServices(browser, error);
+  			}
+  	}
+  });
+
+  BrowserDelegate.addMethod({
+  	selector: 'ssdpBrowser:didFindService:',
+  	instance: true,
+  	arguments: ['SSDPServiceBrowser', 'SSDPService'],
+  	callback: function (browser, service) {
+  			if (this.didFindService) {
+  					this.didFindService(browser, service);
+  			}
+  	}
+  });
+
+  BrowserDelegate.addMethod({
+  	selector: 'ssdpBrowser:didRemoveService:',
+  	instance: true,
+  	arguments: ['SSDPServiceBrowser', 'SSDPService'],
+  	callback: function (browser, service) {
+  			if (this.didRemoveService) {
+  					this.didRemoveService(browser, service);
+  			}
+  	}
+  });
+
+  var browserDelegate = new BrowserDelegate();
+
+  browserDelegate.didNotStartBrowsingForServices = function(browser, error) {
+    console.log('Error: ' + error.localizedDescription);
+  	// Handle error
+  };
+
+  browserDelegate.didFindService = function(browser, service) {
+    console.log('Found service : ' + service.uniqueServiceName);
+  	// Handle found services, e.g.
+  	// service.location, service.serviceType, service.uniqueServiceName, service.server
+  };
+
+  browserDelegate.didRemoveService = function(browser, service) {
+    console.log('Removed service : ' + service.uniqueServiceName);
+  	// Handle removed services
+  };
+
+  browser = new SSDPServiceBrowser(); 
+  browser.delegate = browserDelegate; 
+})($.window);
+
+function startSearch() {
+  browser.startBrowsingForServices('ssdp:all'); 
+}
+
+function stopSearch() {
+  browser.stopBrowsingForServices();
+}

--- a/app/styles/ios/libraries/ssdp.tss
+++ b/app/styles/ios/libraries/ssdp.tss
@@ -1,0 +1,14 @@
+".button": {
+	backgroundColor: "#000",
+	tintColor: "#fff",
+	height: 50,
+	width: 200
+}
+
+".buttonStart": {
+	top: 100
+}
+
+".buttonPause": {
+	bottom: 100
+}

--- a/app/views/libraries/index.xml
+++ b/app/views/libraries/index.xml
@@ -6,6 +6,7 @@
                 <ListItem itemId="charting" platform="ios" title="JBChartView"/>
                 <ListItem itemId="localytics" platform="ios" title="Localytics"/>
                 <ListItem itemId="markdown" platform="ios" title="MMMarkdown"/>
+                <ListItem itemId="ssdp" platform="ios" title="CocoaSSDP"/>
                 <ListItem itemId="shimmer" title="Shimmer"/>
                 <ListItem itemId="gpuImage" platform="android" title="Image Filters (GPUImage)"/>
             </ListSection>

--- a/app/views/libraries/ssdp.xml
+++ b/app/views/libraries/ssdp.xml
@@ -1,0 +1,6 @@
+<Alloy>
+	<Window id="window" title="SSDP-Search">		
+		<Button onClick="startSearch" class="button buttonStart" title="Start search" />
+		<Button onClick="stopSearch" class="button buttonPause" title="Stop search" />
+	</Window>
+</Alloy>

--- a/appc.js
+++ b/appc.js
@@ -37,6 +37,10 @@ module.exports = {
        * name of the package that will be used in the require (if code).
        * the values can either be an Array or String value to the directory
        * where the files are located
+       *
+       * **WARNING**: This functionality has been deprecated in Hyperloop 3.0.0
+       * and will be removed in future versions of Hyperloop. Use Cocoapods or 
+       * place your frameworks in platform/ios instead to be properly handled.
        */
       thirdparty: {
         'MyFramework': {


### PR DESCRIPTION
Are more complex example that allows Titanium developers to use SSDP service discovery within Titanium. Example output:
```

[INFO]   Found service : uuid:95802409-bssa-40e7-8e6c-246511352854::urn:schemas-upnp-org:device:l2tpv3:1
[INFO]   Found service : uuid:fa095ecc-s774-40e7-8e6c-246511352854::urn:schemas-upnp-org:service:ContentDirectory:1
[INFO]   Found service : uuid:fa095ecc-s774-40e7-8e6c-246511352854::urn:schemas-upnp-org:service:ConnectionManager:1
[INFO]   Found service : uuid:fa095ecc-s774-40e7-8e6c-246511352854::urn:microsoft.com:service:X_MS_MediaReceiverRegistrar:1
[INFO]   Found service : uuid:fa095ecc-s774-40e7-8e6c-246511352854::urn:avm.de:service:AVM_ServerStatus:1
[INFO]   Found service : uuid:123402409-bssa-40e7-8e6c-246511352854::urn:schemas-any-com:service:fritzbox:1
[INFO]   Found service : uuid:75802409-bssa-40e7-8e6c-246511352854::urn:schemas-any-com:service:Any:1
[INFO]   Found service : uuid:75802409-bssa-40e7-8e6b-246511352854::urn:schemas-upnp-org:service:WANCommonInterfaceConfig:1
[INFO]   Found service : uuid:75802409-bssa-40e7-8e6a-246511352854::urn:schemas-upnp-org:service:WANDSLLinkConfig:1
[INFO]   Found service : uuid:75802409-bssa-40e7-8e6a-246511352854::urn:schemas-upnp-org:service:WANIPConnection:1
[INFO]   Found service : uuid:75802409-bssa-40e7-8e6a-246511352854::urn:schemas-upnp-org:service:WANIPv6FirewallControl:1
[INFO]   Found service : uuid:75802409-bssa-40e7-9f6c-246511352854::urn:schemas-any-com:service:Any:1
```