### PR TITLE
Fix runtime error in Windows HTTP request example

### DIFF
--- a/app/controllers/windows/httprequest.js
+++ b/app/controllers/windows/httprequest.js
@@ -11,13 +11,13 @@ function startRequest() {
         function(content) {
             Ti.API.info('Response is: ' + content);
             alert('Request completed!');
-            $.btn.setEnabled(true);
+            $.btn.setTouchEnabled(true);
             $.btn.setTitle('Start request!');
         },
         function (err) {
             Ti.API.error('HTTP error');
         });
 
-    $.btn.setEnabled(false);
+    $.btn.setTouchEnabled(false);
     $.btn.setTitle('Loading ...');
 }

--- a/plugins/ti.alloy/hooks/alloy.js
+++ b/plugins/ti.alloy/hooks/alloy.js
@@ -152,10 +152,9 @@ exports.init = function (logger, config, cli, appc) {
 						cmd.map(function(a) {
 							if (/^[^"].* .*[^"]/.test(a)) return '"' + a + '"'; return a;
 						}).join(' ') + '"'].join(' ')], {
-							stdio: 'inherit',
-							windowsVerbatimArguments: true
-						}
-					);
+						stdio: 'inherit',
+						windowsVerbatimArguments: true
+					});
 				} else {
 					logger.info(__('Executing Alloy compile: %s', cmd.join(' ').cyan));
 					child = spawn(cmd.shift(), cmd);

--- a/tiapp.xml
+++ b/tiapp.xml
@@ -66,8 +66,7 @@
 		<target device="android">true</target>
 		<target device="ipad">true</target>
 		<target device="iphone">true</target>
-		<target device="mobileweb">false</target>
-		<target device="windows">false</target>
+		<target device="windows">true</target>
 	</deployment-targets>
 	<sdk-version>7.0.2.GA</sdk-version>
 	<plugins>


### PR DESCRIPTION
The enabled property was removed from Ti.UI.View and all child elements on Windows in 7.0.0 after a deprecation cycle from SDK 5.4.0.

It seems that although this property doesn't exist on a Ti.UI.View in Android and iOS, certain elements like Ti.UI.Button do implement it as the code doesn't fail there, that seems like something that should be removed in future versions?