### PR TITLE
Android: Update Videoplayer test and tiapp.xml

### DIFF
--- a/app/controllers/android/videoplayer.js
+++ b/app/controllers/android/videoplayer.js
@@ -4,7 +4,7 @@ import Gravity from 'android.view.Gravity';
 import LayoutParams from 'android.widget.FrameLayout.LayoutParams';
 import VideoView from 'android.widget.VideoView';
 import Uri from 'android.net.Uri';
-  
+
 let player;
 
 (function(container) {
@@ -13,8 +13,8 @@ let player;
         width: 300,
         height: 200
     };
-    
-    const videoURL = 'http://download.blender.org/peach/bigbuckbunny_movies/BigBuckBunny_320x180.mp4';
+
+    const videoURL = 'http://mirrors.standaloneinstaller.com/video-sample/DLP_PART_2_768k.mp4';
 
     // Convert units for Android
     const width = TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, videoSize.width, activity.getResources().getDisplayMetrics());

--- a/tiapp.xml
+++ b/tiapp.xml
@@ -64,14 +64,14 @@
 	</android>
 	<modules>
 		<!-- Download the latest version from https://github.com/appcelerator-modules/hyperloop-builds/releases -->
-		<module version="5.0.0">hyperloop</module>
+		<module version="5.0.3">hyperloop</module>
 	</modules>
 	<deployment-targets>
 		<target device="android">true</target>
 		<target device="ipad">true</target>
 		<target device="iphone">true</target>
 	</deployment-targets>
-	<sdk-version>9.0.0.GA</sdk-version>
+	<sdk-version>9.0.3.GA</sdk-version>
 	<plugins>
 	<plugin version="1.0">ti.alloy</plugin>
 	</plugins>


### PR DESCRIPTION
This PR updates the videoplayer .mp4 as the current one his hitting a link which is meeting the request limit, not only will this URL not hit a request limit the URL will also match the one used in KitchenSink-v2.

Tiapp.xml also updated to use 9.0.3.GA and Hyperloop 5.0.3. 