### PR TITLE
refactor(android): update examples and add material theme

### DIFF
--- a/app/controllers/android/bottomnavigation.js
+++ b/app/controllers/android/bottomnavigation.js
@@ -2,10 +2,7 @@ import BottomNavigationView from 'com.google.android.material.bottomnavigation.B
 import Activity from 'android.app.Activity';
 import LayoutParams from 'android.widget.FrameLayout.LayoutParams';
 import ViewGroupLayoutParams from 'android.view.ViewGroup.LayoutParams';
-import Color from 'android.graphics.Color';
 import Gravity from 'android.view.Gravity';
-import ColorStateList from 'android.content.res.ColorStateList';
-import R from 'android.R';
 
 const activity = new Activity(Ti.Android.currentActivity);
 
@@ -36,9 +33,7 @@ const activity = new Activity(Ti.Android.currentActivity);
       Ti.API.info(message);
       $.stateLabel.text = message;
 
-      // TODO: Add more logic here to actually change the currently selected item / Titanium view as well
-
-      return false;
+      return true;
     }
   }));
 
@@ -47,7 +42,14 @@ const activity = new Activity(Ti.Android.currentActivity);
   // In the future, this may also be possible by Ti.App.Android.R.*, but thats not available so far.
   bottomNav.inflateMenu(resIDFromString('tabs', 'menu'));
   bottomNav.setItemBackgroundResource(resIDFromString('tabs_background_color', 'color')); 
-  
+
+  // Add a (5) badge on the 2nd tab item.
+  // Note: This requires the app/activity to use a "Theme.MaterialComponents" based theme.
+  var menuItemId = bottomNav.getMenu().getItem(1).getItemId();
+  var badgeDrawable = bottomNav.getOrCreateBadge(menuItemId);
+  badgeDrawable.setVisible(true);
+  badgeDrawable.setNumber(5);
+
   // Uncomment to use custom item colors
   // 
   // const states = [

--- a/app/controllers/android/touches.js
+++ b/app/controllers/android/touches.js
@@ -13,15 +13,26 @@ import Activity from 'android.app.Activity';
 
 	const drag = new OnTouchListener({
 		onTouch: (v, event) => {
-			const action = event.getAction();
-			if (action == MotionEvent.ACTION_MOVE || action == MotionEvent.ACTION_UP) {
-				const params = LayoutParams.cast(v.getLayoutParams());
-				// FIXME We're cheating by adjusting for the position of the parent view on screen here
-				// Ideally we'd use View.getLocationOnScreen(int[])
-				// http://stackoverflow.com/questions/2224844/how-to-get-the-absolute-coordinates-of-a-view
-				params.topMargin = event.getRawY() - 150 - v.getHeight();
-				params.leftMargin = event.getRawX() - 30 - (v.getWidth() / 2);
-				v.setLayoutParams(params);
+			const action = event.getActionMasked();
+			switch (action) {
+				case MotionEvent.ACTION_DOWN:
+					const params = LayoutParams.cast(v.getLayoutParams());
+					v.setTag({
+						leftMargin: params.leftMargin,
+						topMargin: params.topMargin,
+						dragStartX: event.getRawX(),
+						dragStartY: event.getRawY()
+					});
+					break;
+				case MotionEvent.ACTION_MOVE:
+					const tag = v.getTag();
+					if (tag) {
+						const params = LayoutParams.cast(v.getLayoutParams());
+						params.leftMargin = tag.leftMargin + (event.getRawX() - tag.dragStartX);
+						params.topMargin = tag.topMargin + (event.getRawY() - tag.dragStartY);
+						v.setLayoutParams(params);
+					}
+					break;
 			}
 			return true;
 		}
@@ -29,17 +40,16 @@ import Activity from 'android.app.Activity';
 
 	// Create a native layout to add our boxes to
 	const main = new FrameLayout(activity);
-	main.setLayoutParams(new LayoutParams(ViewGroupLayoutParams.MATCH_PARENT, ViewGroupLayoutParams.MATCH_PARENT, Gravity.TOP));
+	main.setLayoutParams(new LayoutParams(
+		ViewGroupLayoutParams.MATCH_PARENT,
+		ViewGroupLayoutParams.MATCH_PARENT,
+		Gravity.TOP));
 
 	// Let's create a box for each color constant
 	const colors = [
 		Color.BLUE,
-		Color.CYAN,
-		Color.DKGRAY,
 		Color.GRAY,
 		Color.GREEN,
-		Color.LTGRAY,
-		Color.MAGENTA,
 		Color.RED,
 		Color.WHITE,
 		Color.YELLOW
@@ -47,8 +57,8 @@ import Activity from 'android.app.Activity';
 	for (let i = 0; i < colors.length; i++) {
 		const temp = new View(activity);
 		temp.setBackgroundColor(colors[i]);
-		const layoutParams = new LayoutParams(50, 50, Gravity.TOP);
-		layoutParams.setMargins(0, i * 50, 0, 0);
+		const layoutParams = new LayoutParams(150, 150, Gravity.TOP);
+		layoutParams.setMargins(0, i * 150, 0, 0);
 		temp.setLayoutParams(layoutParams);
 		temp.setOnTouchListener(drag);
 		main.addView(temp);

--- a/app/platform/android/build.gradle
+++ b/app/platform/android/build.gradle
@@ -2,7 +2,7 @@
 dependencies {
 	implementation 'com.android.volley:volley:1.1.1'
 	implementation 'com.facebook.shimmer:shimmer:0.5.0'
-	implementation 'com.google.android.material:material:1.1.0'
+	implementation 'com.google.android.material:material:1.2.0'
 	implementation 'io.resourcepool:ssdp-client:2.3.0'
 	implementation 'jp.co.cyberagent.android:gpuimage:2.0.4'
 }

--- a/app/platform/android/res/layout/main_content.xml
+++ b/app/platform/android/res/layout/main_content.xml
@@ -1,6 +1,6 @@
 <androidx.coordinatorlayout.widget.CoordinatorLayout
     android:id="@+id/main_content"
-    android:theme="@style/Theme.AppCompat.Light"
+    android:theme="@style/Theme.MaterialComponents.Light.Bridge"
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"

--- a/app/platform/android/res/values/custom_theme.xml
+++ b/app/platform/android/res/values/custom_theme.xml
@@ -7,7 +7,7 @@
 	<color name="black_transparent">#66000000</color>
 	<color name="white">#FFFFFF</color>
 
-	<style name="appcelerator" parent="@style/Theme.AppCompat">
+	<style name="appcelerator" parent="Theme.MaterialComponents.Bridge">
 		<item name="colorPrimary">@color/primary</item>
 		<item name="colorAccent">@color/accent</item>
 		<item name="android:statusBarColor">@color/primary_dark</item>

--- a/app/views/android/blur.xml
+++ b/app/views/android/blur.xml
@@ -1,9 +1,6 @@
 <Alloy>
-	<Window id="win" title="Blur">
-
-		<ScrollView>
-			<View class="vbox" id="blur_container" />
-		</ScrollView>
-
+	<Window id="win" title="Blur" onOpen="onOpen">
+		<Button id="blurButton" bottom="30" onClick="onBlurImage">Blur Image</Button>
+		<Button id="unblurButton" bottom="30" visible="false" onClick="onUnblurImage">Unblur Image</Button>
 	</Window>
 </Alloy>

--- a/app/views/android/touches.xml
+++ b/app/views/android/touches.xml
@@ -1,9 +1,6 @@
 <Alloy>
 	<Window id="win" title="Touches">
-
-		<ScrollView>
-			<View class="vbox" id="touch_container" />
-		</ScrollView>
-
+		<Label bottom="30" touchEnabled="false" text="Drag the squares."/>
+		<View class="vbox" id="touch_container"/>
 	</Window>
 </Alloy>


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-27714

**Note:**
These changes will work on Titanium 9.0.0 and higher.

**Summary:**
- Updated to use Google's material theme.
- Updated "Bottom Navigation View" example:
  * Now shows how to add a badge number to a tab. (Requires material theme.)
  * Fixed tab selection. Tapping a tab will now highlight it.
- Updated "Blur" example:
  * Now blurs an image instead of lines.
  * Shows a "Blur" and "Unblur" button like iOS. (For showing before/after.)
- Updated "Touches" example:
  * Fixed touch dragging a square. (Never worked before.)
  * Made squares bigger to make them easier to drag.

**Screenshots:**
![HyperloopBlurBefore](https://user-images.githubusercontent.com/26234558/90839214-ca83c480-e30b-11ea-9d9b-b2e55e76984e.png) ![HyperloopBlurAfter](https://user-images.githubusercontent.com/26234558/90839217-ce174b80-e30b-11ea-81f1-d09c6c08d2ec.png)
![HyperloopBottomNavView](https://user-images.githubusercontent.com/26234558/90839224-d2436900-e30b-11ea-84c4-573c6c885657.png) ![HyperloopTouches](https://user-images.githubusercontent.com/26234558/90839232-d53e5980-e30b-11ea-94fd-3c7d22d64695.png)

