### PR TITLE
chore(android): update library dependencies

### DIFF
--- a/app/platform/android/build.gradle
+++ b/app/platform/android/build.gradle
@@ -1,8 +1,8 @@
 
 dependencies {
-	implementation 'com.android.volley:volley:1.1.1'
+	implementation 'com.android.volley:volley:1.2.0'
 	implementation 'com.facebook.shimmer:shimmer:0.5.0'
 	implementation 'com.google.android.material:material:1.2.0'
-	implementation 'io.resourcepool:ssdp-client:2.3.0'
-	implementation 'jp.co.cyberagent.android:gpuimage:2.0.4'
+	implementation 'io.resourcepool:ssdp-client:2.4.3'
+	implementation 'jp.co.cyberagent.android:gpuimage:2.1.0'
 }


### PR DESCRIPTION
**JIRA:**
https://jira.appcelerator.org/browse/TIMOB-28456

**Notes:**
- Needed to avoid build failures when switching from deprecated JCenter repo to MavenCentral.
- Old versions were not migrated to MavenCentral. And newer versions are only available in new repo.
- This PR needs to be merged so we can successfully test SDK PR: https://github.com/appcelerator/titanium_mobile/pull/12821

